### PR TITLE
[Bug] D126807: semop(1): encountered an error: Identifier removed: pa…

### DIFF
--- a/regrep
+++ b/regrep
@@ -820,7 +820,7 @@ my $semaphore;
 END {
     if ($semaphore) {
         semctl $semaphore, 0, IPC_RMID, 0
-            or print "semop failed: $!\n";
+            or print STDERR "semop failed: $!\n";
     }
 }
 
@@ -1311,4 +1311,3 @@ if (not $opt_pipefilenames and not @ARGV) {
 
 my $rc = $$options{OpenFailures}? 2: $nrmatches == 0? 1: 0;
 exit $rc;
-


### PR DESCRIPTION
…ckaging failed to build on miescher and uksw-cbld1 and ussw-cbld00

regrep: Over the weekend, an enduring and baffling problem whereby work's Debian packaging quite often fails on one particular machine, in fakeroot, happened for the first time in the "srcdoc" phase of a build.  The message that made it into the build log was:

WARNING: couldn't open 'semop failed: Invalid argument' for reading

That didn't seem right.  Why are we processing an error message like it's a filename?  I don't have sufficient evidence to pin it on this for sure, but it looks likely from at least one of the two code sites that produce such a warning that it was due to the lack of a STDERR here.

Now surely this failure is telling me something about the root cause of all the other build failures.  I can't see how it could be due to regrep but this failure suggests that it's not fakeroot either.  Could some rogue process really be going round removing other people's semaphores on this machine?  Yikes!  I wonder how I can track it down...